### PR TITLE
Update NuGet and import EndToEndTests from Gist

### DIFF
--- a/NEventStoreExample.Test/EndToEndTest.cs
+++ b/NEventStoreExample.Test/EndToEndTest.cs
@@ -1,0 +1,181 @@
+﻿namespace NEventStoreExample.Test
+{
+  using System;
+  using CommonDomain.Core;
+  using CommonDomain.Persistence.EventStore;
+  using MemBus;
+  using MemBus.Configurators;
+  using MemBus.Subscribing;
+  using NEventStore;
+  using NEventStore.Dispatcher;
+  using NEventStoreExample.CommandHandler;
+  using NEventStoreExample.EventHandler;
+  using NEventStoreExample.Infrastructure;
+  using NEventStoreExample.Model;
+  using Shouldly;
+  using Xunit;
+
+  public class EndToEndTest
+  {
+    private readonly SomeAwesomeUi _client;
+    private readonly IBus _bus;
+
+    // Here, I'm wiring up my MemBus instance and telling it how to resolve my subscribers
+    // MemBus also has an awesome way to resolve subscribers from an IoC container. In prod,
+    // I'll wire my subscribers into StructureMap and have MemBus resolve them from there.
+    // I'm also initializing my awesome test client UI which, if you'll recall from way back at the start
+    // simply publishes commands to my MemBus instance (and, again, it could be whatever)
+    public EndToEndTest()
+    {
+      _bus = BusSetup.StartWith<Conservative>()
+          .Apply<FlexibleSubscribeAdapter>(a =>
+          {
+            a.ByInterface(typeof(IEventHandler<>));
+            a.ByInterface(typeof(ICommandHandler<>));
+          })
+          .Construct();
+
+      _client = new SomeAwesomeUi(_bus);
+    }
+
+    [Fact]
+    public void CanPublishCreateAccountCommand()
+    {
+      Should.NotThrow(() => _client.CreateNewAccount());
+    }
+
+    [Fact]
+    public void CanReceiveCreateAccountCommand()
+    {
+      var store = Wireup.Init().UsingInMemoryPersistence().Build();
+      var handler = new CreateAccountCommandHandler(new EventStoreRepository(store, new AggregateFactory(), new ConflictDetector()));
+
+      _bus.Subscribe(handler);
+
+      Should.NotThrow(() => _client.CreateNewAccount());
+    }
+
+    [Fact]
+    public void CreateAccountEventIsStored()
+    {
+      var store = Wireup.Init().UsingInMemoryPersistence().Build();
+
+      var repository = new EventStoreRepository(store, new AggregateFactory(), new ConflictDetector());
+      var handler = new CreateAccountCommandHandler(repository);
+      var eventHandler = new AccountDenormalizer();
+
+      _bus.Subscribe(handler);
+      _bus.Subscribe(eventHandler);
+      var accountId = _client.CreateNewAccount();
+
+      store.OpenStream(accountId, 0, int.MaxValue).CommittedEvents.Count.ShouldBeGreaterThan(0);
+    }
+
+    [Fact]
+    public void CanLoadAccountFromEventStore()
+    {
+      var store = Wireup.Init().UsingInMemoryPersistence().Build();
+      var repository = new EventStoreRepository(store, new AggregateFactory(), new ConflictDetector());
+      var handler = new CreateAccountCommandHandler(repository);
+
+      _bus.Subscribe(handler);
+
+      Guid accountID = Guid.NewGuid();
+      string name = Guid.NewGuid().ToString();
+      string twitter = Guid.NewGuid().ToString();
+
+      _client.CreateNewAccount(accountID, name, twitter);
+
+      Account account = repository.GetById<Account>(accountID);
+
+      account.ShouldNotBe(null);
+      account.Name.ShouldBe(name);
+      account.Twitter.ShouldBe(twitter);
+    }
+
+    [Fact]
+    public void CreateAccountEventIsPublishedToBus()
+    {
+      var store = Wireup.Init().UsingInMemoryPersistence()
+                      .UsingSynchronousDispatchScheduler()
+                              .DispatchTo(new DelegateMessageDispatcher(c => DelegateDispatcher.DispatchCommit(_bus, c)))
+                      .Build();
+
+      var handler = new CreateAccountCommandHandler(new EventStoreRepository(store, new AggregateFactory(), new ConflictDetector()));
+      var denormalizer = new AccountDenormalizer();
+
+      _bus.Subscribe(handler);
+      _bus.Subscribe(denormalizer);
+
+      Guid accountID = Guid.NewGuid();
+      string name = Guid.NewGuid().ToString();
+      string twitter = Guid.NewGuid().ToString();
+
+      _client.CreateNewAccount(accountID, name, twitter);
+
+      denormalizer.AccountName.ShouldBe(name);
+    }
+
+    [Fact]
+    public void DeactivingAccountDoesntRetriggerInitialCreate()
+    {
+      var store = Wireup.Init().UsingInMemoryPersistence()
+                      .UsingSynchronousDispatchScheduler()
+                              .DispatchTo(new DelegateMessageDispatcher(c => DelegateDispatcher.DispatchCommit(_bus, c)))
+                      .Build();
+
+      var createHandler = new CreateAccountCommandHandler(new EventStoreRepository(store, new AggregateFactory(), new ConflictDetector()));
+      var deactivateHandler = new CloseAccountCommandHandler(new EventStoreRepository(store, new AggregateFactory(), new ConflictDetector()));
+      var denormalizer = new AccountDenormalizer();
+
+      _bus.Subscribe(createHandler);
+      _bus.Subscribe(deactivateHandler);
+      _bus.Subscribe(denormalizer);
+
+      Guid accountID = Guid.NewGuid();
+      string name = Guid.NewGuid().ToString();
+      string twitter = Guid.NewGuid().ToString();
+
+      _client.CreateNewAccount(accountID, name, twitter);
+      _client.CloseAccount(accountID);
+
+      denormalizer.AccountName.ShouldBe(name);
+      denormalizer.IsActive.ShouldBe(false);
+      store.OpenStream(accountID, 0, int.MaxValue).CommittedEvents.Count.ShouldBe(2);
+    }
+
+
+    //For fun, run this with the Debugger (eg, if using TDD.NET then right click on this method and select Test With -> Debugger.
+    //Put break points in various spots of the code above and see what happens.
+    [Fact]
+    public void TyingItTogether()
+    {
+      var store = Wireup.Init().UsingInMemoryPersistence()
+                      .UsingSynchronousDispatchScheduler()
+                              .DispatchTo(new DelegateMessageDispatcher(c => DelegateDispatcher.DispatchCommit(_bus, c)))
+                      .Build();
+
+      var createHandler = new CreateAccountCommandHandler(new EventStoreRepository(store, new AggregateFactory(), new ConflictDetector()));
+      var deactivateHandler = new CloseAccountCommandHandler(new EventStoreRepository(store, new AggregateFactory(), new ConflictDetector()));
+      var denormalizer = new AccountDenormalizer();
+
+      _bus.Subscribe(createHandler);
+      _bus.Subscribe(deactivateHandler);
+
+      _bus.Subscribe(denormalizer);
+      _bus.Subscribe(new KaChingNotifier());
+      _bus.Subscribe(new OmgSadnessNotifier());
+
+      Guid accountID = Guid.NewGuid();
+      string name = Guid.NewGuid().ToString();
+      string twitter = Guid.NewGuid().ToString();
+
+      _client.CreateNewAccount(accountID, name, twitter);
+      _client.CloseAccount(accountID);
+
+      denormalizer.AccountName.ShouldBe(name);
+      denormalizer.IsActive.ShouldBe(false);
+      store.OpenStream(accountID, 0, int.MaxValue).CommittedEvents.Count.ShouldBe(2);
+    }
+  }
+}

--- a/NEventStoreExample.Test/NEventStoreExample.Test.csproj
+++ b/NEventStoreExample.Test/NEventStoreExample.Test.csproj
@@ -35,11 +35,18 @@
     <Reference Include="KellermanSoftware.Compare-NET-Objects">
       <HintPath>..\packages\CompareObjects.1.0.2\lib\net35\KellermanSoftware.Compare-NET-Objects.dll</HintPath>
     </Reference>
+    <Reference Include="MemBus, Version=3.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\MemBus.3.0.1\lib\portable-windows8+net45+wp8\MemBus.dll</HintPath>
+    </Reference>
     <Reference Include="NEventStore">
       <HintPath>..\packages\NEventStore.5.1.0\lib\net40\NEventStore.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework">
       <HintPath>..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
+    </Reference>
+    <Reference Include="Shouldly">
+      <HintPath>..\packages\Shouldly.2.4.0\lib\net40\Shouldly.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -48,8 +55,12 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
+    <Reference Include="xunit">
+      <HintPath>..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="EndToEndTest.cs" />
     <Compile Include="EventSpecification.cs" />
     <Compile Include="InMemoryEventRepository.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/NEventStoreExample.Test/NEventStoreExample.Test.csproj
+++ b/NEventStoreExample.Test/NEventStoreExample.Test.csproj
@@ -36,7 +36,7 @@
       <HintPath>..\packages\CompareObjects.1.0.2\lib\net35\KellermanSoftware.Compare-NET-Objects.dll</HintPath>
     </Reference>
     <Reference Include="NEventStore">
-      <HintPath>..\packages\NEventStore.5.0.0.84\lib\net40\NEventStore.dll</HintPath>
+      <HintPath>..\packages\NEventStore.5.1.0\lib\net40\NEventStore.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework">
       <HintPath>..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
@@ -67,12 +67,6 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
-  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/NEventStoreExample.Test/packages.config
+++ b/NEventStoreExample.Test/packages.config
@@ -1,6 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CompareObjects" version="1.0.2" targetFramework="net45" />
+  <package id="MemBus" version="3.0.1" targetFramework="net45" />
   <package id="NEventStore" version="5.1.0" targetFramework="net45" />
   <package id="NUnit" version="2.6.3" targetFramework="net45" />
+  <package id="Shouldly" version="2.4.0" targetFramework="net45" />
+  <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/NEventStoreExample.Test/packages.config
+++ b/NEventStoreExample.Test/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CompareObjects" version="1.0.2" targetFramework="net45" />
-  <package id="NEventStore" version="5.0.0.84" targetFramework="net45" />
+  <package id="NEventStore" version="5.1.0" targetFramework="net45" />
   <package id="NUnit" version="2.6.3" targetFramework="net45" />
 </packages>

--- a/NEventStoreExample.sln
+++ b/NEventStoreExample.sln
@@ -1,20 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.30110.0
+VisualStudioVersion = 12.0.30723.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NEventStoreExample", "NEventStoreExample\NEventStoreExample.csproj", "{60BA00D5-1865-4854-9192-BA72E18A76B2}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NEventStoreExample.Test", "NEventStoreExample.Test\NEventStoreExample.Test.csproj", "{210BFD16-EDCF-4895-90E6-FACF137EAFE5}"
 	ProjectSection(ProjectDependencies) = postProject
 		{60BA00D5-1865-4854-9192-BA72E18A76B2} = {60BA00D5-1865-4854-9192-BA72E18A76B2}
-	EndProjectSection
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{52ECD38E-B734-496C-A29C-FB5B51C9BA80}"
-	ProjectSection(SolutionItems) = preProject
-		.nuget\NuGet.Config = .nuget\NuGet.Config
-		.nuget\NuGet.exe = .nuget\NuGet.exe
-		.nuget\NuGet.targets = .nuget\NuGet.targets
 	EndProjectSection
 EndProject
 Global

--- a/NEventStoreExample/CommandHandler/CreateAccountCommandHandler.cs
+++ b/NEventStoreExample/CommandHandler/CreateAccountCommandHandler.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using CommonDomain;
+using CommonDomain.Core;
 using CommonDomain.Persistence;
 using NEventStoreExample.Command;
 using NEventStoreExample.Infrastructure;

--- a/NEventStoreExample/Infrastructure/DelegateDispatcher.cs
+++ b/NEventStoreExample/Infrastructure/DelegateDispatcher.cs
@@ -3,30 +3,31 @@ using NEventStore;
 
 namespace NEventStoreExample.Infrastructure
 {
-    // Ok, so this is where things get a little.... interesting
-    // EventStore is sort of my coordinator for everything
-    // When I create a new domain object, I issue commands to it. It, in turn, raises events to change its internal state.
-    //
-    // Again, thing of the current state of a domain object as what you get after all events that built it are applied.
-    // new Person("@benhyr") might raise a PersonCreatedEvent. Then person.UpdateTwitterId("@hyrmn") raises a PersonUpdatedEvent
-    // When I load that Person from the EventStore, rather than getting Person.TwitterId from a db field, I'm getting PersonCreatedEvent
-    // (which sets the TwitterId initially) and then PersonUpdatedEvent (which updates the TwitterId to the new value)
-    //
-    // Now, back to this class. When I raise events, they're uncommitted until I persist them back to the EventStore.
-    // By default, we assume others might be interested in these uncommitted events. Of course, it's EventStore not EventStoreAndMessageBus
-    // (although EventStore could do some basic stuff for us). So, we're telling EventStore to publish to our MemBus bus... at some point,
-    // we might put NSB or MassTransit or EasyNetQ or whatever in place.
-    public static class DelegateDispatcher
+  // Ok, so this is where things get a little.... interesting
+  // EventStore is sort of my coordinator for everything
+  // When I create a new domain object, I issue commands to it. It, in turn, raises events to change its internal state.
+  //
+  // Again, thing of the current state of a domain object as what you get after all events that built it are applied.
+  // new Person("@benhyr") might raise a PersonCreatedEvent. Then person.UpdateTwitterId("@hyrmn") raises a PersonUpdatedEvent
+  // When I load that Person from the EventStore, rather than getting Person.TwitterId from a db field, I'm getting PersonCreatedEvent
+  // (which sets the TwitterId initially) and then PersonUpdatedEvent (which updates the TwitterId to the new value)
+  //
+  // Now, back to this class. When I raise events, they're uncommitted until I persist them back to the EventStore.
+  // By default, we assume others might be interested in these uncommitted events. Of course, it's EventStore not EventStoreAndMessageBus
+  // (although EventStore could do some basic stuff for us). So, we're telling EventStore to publish to our MemBus bus... at some point,
+  // we might put NSB or MassTransit or EasyNetQ or whatever in place.
+  public static class DelegateDispatcher
+  {
+    public static void DispatchCommit(IPublisher bus, ICommit commit)
     {
-        public static void DispatchCommit(IPublisher bus, ICommit commit)
-        {
-            // This is where we'd hook into our messaging infrastructure, such as NServiceBus,
-            // MassTransit, WCF, or some other communications infrastructure.
-            // This can be a class as well--just implement IDispatchCommits.
-            foreach (var @event in commit.Events)
-            {
-                bus.Publish(@event.Body);
-            }
-        }
+      // This is where we'd hook into our messaging infrastructure, such as NServiceBus,
+      // MassTransit, WCF, or some other communications infrastructure.
+      // This can be a class as well--just implement IDispatchCommits.
+      foreach (var @event in commit.Events)
+      {
+        System.Diagnostics.Debug.Print(string.Format("Dispatch {0}", @event.Body.GetType().Name));
+        bus.Publish(@event.Body);
+      }
     }
+  }
 }

--- a/NEventStoreExample/Model/Account.cs
+++ b/NEventStoreExample/Model/Account.cs
@@ -20,6 +20,7 @@ namespace NEventStoreExample.Model
         private Account(Guid id)
         {
             Id = new AccountId(id);
+            base.Id = id;
         }
 
         public new AccountId Id { get; private set; }

--- a/NEventStoreExample/NEventStoreExample.csproj
+++ b/NEventStoreExample/NEventStoreExample.csproj
@@ -12,6 +12,7 @@
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/NEventStoreExample/NEventStoreExample.csproj
+++ b/NEventStoreExample/NEventStoreExample.csproj
@@ -12,7 +12,6 @@
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
-    <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -38,7 +37,7 @@
       <HintPath>..\packages\MemBus.3.0.1\lib\portable-windows8+net45+wp8\MemBus.dll</HintPath>
     </Reference>
     <Reference Include="NEventStore">
-      <HintPath>..\packages\NEventStore.5.0.0.84\lib\net40\NEventStore.dll</HintPath>
+      <HintPath>..\packages\NEventStore.5.1.0\lib\net40\NEventStore.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -77,12 +76,6 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
-  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/NEventStoreExample/SomeAwesomeUi.cs
+++ b/NEventStoreExample/SomeAwesomeUi.cs
@@ -1,28 +1,39 @@
 ﻿using System;
+using CommonDomain.Persistence;
 using MemBus;
 using NEventStoreExample.Command;
+using NEventStoreExample.Model;
 
 namespace NEventStoreExample
 {
-    public class SomeAwesomeUi
+  public class SomeAwesomeUi
+  {
+    private readonly IBus bus;
+    private IRepository repository;
+
+    public SomeAwesomeUi(IBus bus)
     {
-        private readonly IBus bus;
-
-        public SomeAwesomeUi(IBus bus)
-        {
-            this.bus = bus;
-        }
-
-        public void CreateNewAccount(Guid accountId, string name, string twitter)
-        {
-            var createCommand = new CreateAccountCommand(accountId, name, twitter);
-            bus.Publish(createCommand);
-        }
-
-        public void CloseAccount(Guid accountId)
-        {
-            var closeCommand = new CloseAccountCommand(accountId);
-            bus.Publish(closeCommand);
-        }
+      this.bus = bus;
+      this.repository = repository;
     }
+
+    public Guid CreateNewAccount()
+    {
+      Guid accountID = Guid.NewGuid();
+      CreateNewAccount(accountID, Guid.NewGuid().ToString(), Guid.NewGuid().ToString());
+      return accountID;
+    }
+
+    public void CreateNewAccount(Guid accountId, string name, string twitter)
+    {
+      var createCommand = new CreateAccountCommand(accountId, name, twitter);
+      bus.Publish(createCommand);
+    }
+
+    public void CloseAccount(Guid accountId)
+    {
+      var closeCommand = new CloseAccountCommand(accountId);
+      bus.Publish(closeCommand);
+    }
+  }
 }

--- a/NEventStoreExample/packages.config
+++ b/NEventStoreExample/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="MemBus" version="3.0.1" targetFramework="net45" />
-  <package id="NEventStore" version="5.0.0.84" targetFramework="net45" />
+  <package id="NEventStore" version="5.1.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Updating NuGet NEventStore to 5.1.0 as the version you'd used (5.0.0.84) is no longer available, get it all compiling again (minor), import the EndToEndTests you'd originally included in your Gist and complete what I believe was their intent. Doesn't add much new (though the EndToEndTests are pretty helpful), but an updated/working base from which to continue today...